### PR TITLE
bump up version number

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/chemcoord-{{ version }}.tar.gz
-  sha256: 232134bc7f0c66835aaa9147d7524f42467ef612f74af22c0f117c520359ce6b
+  sha256: dbbbfbe0734e5b9f851b86bb041ecf535a83c428ad67bf71381ac70ee1661878
 
 build:
   noarch: python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "chemcoord" %}
-{% set version = "2.1.0" %}
+{% set version = "2.1.1" %}
 
 package:
   name: {{ name|lower }}
@@ -17,13 +17,13 @@ build:
 requirements:
   host:
     - pip
-    - python >=3.6
+    - python >=3.7
   run:
     - numba >=0.35
     - numpy >=1.0
-    - pandas >=1.0,<2
+    - pandas >=1.0
     - pymatgen
-    - python >=3.6
+    - python >=3.7
     - scipy
     - six
     - sortedcontainers


### PR DESCRIPTION
- bump up version number
- chemcoord works now with pandas >= 2, remove constraint

Dear @ghutchis,

Could you perhaps have a brief look, if this update is correct?
The update `v2.1.0 -> v2.1.1` of chemcoord only accounted for changed APIs of numba, pandas, and numpy and does not add new features.


Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.
